### PR TITLE
fix code typo on phpcd.vim

### DIFF
--- a/autoload/phpcd.vim
+++ b/autoload/phpcd.vim
@@ -297,7 +297,7 @@ function! phpcd#LocateSymbol(symbol, symbol_context, symbol_namespace, current_i
 	else " {{{
 		if a:symbol =~ '^\$'
 			return unknow_location
-		else if a:symbol =~ '\v\C^[A-Z]'
+		elseif a:symbol =~ '\v\C^[A-Z]'
 			let [classname, namespace] = phpcd#ExpandClassName(a:symbol, a:symbol_namespace, a:current_imports)
 			let full_classname = s:GetFullName(namespace, classname)
 			let [path, line] = rpc#request(g:phpcd_channel_id, 'location', full_classname, '')


### PR DESCRIPTION
- Fix 'elseif' statement typo on phpcd.vim;